### PR TITLE
Use default kubernetes client to connect to tiller.

### DIFF
--- a/charts/hyperspace/templates/projects/portal/configmap.yaml
+++ b/charts/hyperspace/templates/projects/portal/configmap.yaml
@@ -13,8 +13,5 @@ data:
       enabled: true
       jwksUrl: {{ template "keycloak.baseUrl" . }}/auth/realms/{{ .Values.hyperspace.keycloak.realm }}/protocol/openid-connect/certs
       jwtAlgorithm: RS256
-    tiller:
-      service: tiller-deploy.kube-system
-      port: 44134
     charts:
       workspace: http://storage.googleapis.com/fairspace-helm/workspace-0.6.7-SNAPSHOT.tgz

--- a/charts/hyperspace/templates/projects/portal/deployment.yaml
+++ b/charts/hyperspace/templates/projects/portal/deployment.yaml
@@ -29,6 +29,9 @@ spec:
 {{ toYaml .Values.podAnnotations.portal | indent 8 }}
 {{- end }}
     spec:
+      {{- if .Values.hyperspace.rbac.enabled }}
+      serviceAccountName: {{ .Release.Name }}-portal
+      {{- end }}
       containers:
       - name: {{ template "portal.fullname" . }}
         image: "{{ .Values.portal.image.image }}:{{ .Values.portal.image.tag }}"

--- a/charts/hyperspace/templates/projects/portal/rbac.yaml
+++ b/charts/hyperspace/templates/projects/portal/rbac.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.hyperspace.rbac.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-portal
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: portal
+    chart: {{ template "hyperspace.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-port-forwarder
+  namespace: kube-system
+  labels:
+    app: portal
+    chart: {{ template "hyperspace.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups: [""]       # "" indicates the core API group
+    resources: ["pods", "pods/portforward"]
+    verbs: ["get", "list", "create"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-port-forwarder
+  namespace: kube-system
+  labels:
+    app: portal
+    chart: {{ template "hyperspace.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-portal
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-port-forwarder
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/hyperspace/values.yaml
+++ b/charts/hyperspace/values.yaml
@@ -6,6 +6,8 @@ fairspaceImagePullSecret:
 # Setup ingress for hyperspace components
 hyperspace:
     name: Fairspace
+    rbac:
+        enabled: true
     keycloak:
         clientId: hyperspace
         clientSecret:

--- a/projects/portal/README.md
+++ b/projects/portal/README.md
@@ -1,0 +1,14 @@
+# Organisation portal backend
+
+This application manages the workspaces in the organisation portal. It consists of a
+basic interface that calls [helm](https://helm.sh) using the [microbean library](https://microbean.github.io/microbean-helm/index.html) for deployment of workspaces.
+
+## Configuration
+Configuration can be done by adding an `application.yaml` file. The parameters that can be set 
+can be found in the [Config.java](src/main/java/io/fairspace/portal/Config.java).
+
+The connection with helm relies on a connection to the kubernetes master API for setting up a 
+port-forward to tiller. Our helm chart set up a specific service account that has the
+necessary authorizations, which is used without further application configuration. More detailed
+configuration of the kubernetes client can be done using environment variables or files. See https://github.com/fabric8io/kubernetes-client#configuring-the-client 
+for more information.

--- a/projects/portal/application.yaml
+++ b/projects/portal/application.yaml
@@ -5,8 +5,5 @@ auth:
   jwksUrl: "https://keycloak.hyperspace.ci.fairway.app/auth/realms/ci/protocol/openid-connect/certs"
   # JWK encryption algorithm. Defaults to "RS256"
   jwtAlgorithm: RS256
-tiller:
-  service: tiller-deploy.kube-system
-  port: 44134
 charts:
   workspace: http://storage.googleapis.com/fairspace-helm/workspace-0.6.7-SNAPSHOT.tgz

--- a/projects/portal/src/main/java/io/fairspace/portal/Config.java
+++ b/projects/portal/src/main/java/io/fairspace/portal/Config.java
@@ -12,7 +12,6 @@ public class Config {
     public static final String WORKSPACE_CHART = "workspace";
 
     public final Auth auth = new Auth();
-    public final Tiller tiller = new Tiller();
     public final Map<String, URL> charts = new HashMap<>();
 
     public static class Auth {
@@ -21,11 +20,6 @@ public class Config {
         public String jwksUrl = "https://keycloak.hyperspace.ci.fairway.app/auth/realms/ci/protocol/openid-connect/certs";
 
         public String jwtAlgorithm = "RS256";
-    }
-
-    public static class Tiller {
-        public String service = "tiller-deploy.kube-system";
-        public int port = 44134;
     }
 
     @Override


### PR DESCRIPTION
Using the kubernetes client is the suggested way to connect to
tiller. It is secured by using a service-account with limited
access rights.
Using this approach also prepares for helm-v3, which will directly
talk to the kubernetes api, instead of using a tiller pod.

Fixes VRE-948