### PR TITLE
Add C4 architecture diagrams for reference

### DIFF
--- a/docs/component-diagram-portal.puml
+++ b/docs/component-diagram-portal.puml
@@ -1,0 +1,27 @@
+@startuml Hyperspace
+!includeurl https://raw.githubusercontent.com/RicardoNiepel/C4-PlantUML/release/1-0/C4_Component.puml
+
+title Component diagram for Organisation Portal backend
+
+LAYOUT_WITH_LEGEND()
+
+Person(admin, "Administrator", "An organisation wide administrator for fairspace")
+Person(user, "Regular user", "User without additional privileges")
+
+System_Boundary(portal, "Organisation portal") {
+    Component(searchApp, "Search App", "Spark app", "Proxies search queries to the right indices")
+    Component(workspacesApp, "Workspaces App", "Spark app", "Manages workspaces and apps")
+}
+
+Container(elasticsearch, "ElasticSearch", "Java", "Search index for information from all connected workspaces")
+Container(rabbitmq, "Message Bus", "RabbitMQ", "Transport for business events")
+
+System_Ext(tiller, "Tiller", "Server side component managing helm releases")
+
+Rel(admin, workspacesApp, "Manages workspaces and apps")
+Rel(user, searchApp, "Logs in at ")
+
+Rel(workspacesApp, tiller, "Manages releases with")
+Rel(searchApp, elasticsearch, "Queries appropriate indices")
+Rel(workspacesApp, rabbitmq, "Sends workspace and app events to", "AMQP")
+@enduml

--- a/docs/container-diagram.puml
+++ b/docs/container-diagram.puml
@@ -1,0 +1,36 @@
+@startuml Hyperspace
+!includeurl https://raw.githubusercontent.com/RicardoNiepel/C4-PlantUML/release/1-0/C4_Container.puml
+
+title Container diagram for Hyperspace
+
+LAYOUT_WITH_LEGEND()
+
+Person(admin, "Administrator", "An organisation wide administrator for fairspace")
+
+System_Boundary(hyperspace, "Hyperspace") {
+    Container(keycloak, "Keycloak", "Java, WildFly", "Handles authentication and authorization")
+    Container(elasticsearch, "ElasticSearch", "Java", "Search index for information from all connected workspaces")
+    Container(frontend, "Frontend", "Javascript, React", "Allows administrators to manage workspaces, apps and users")
+    Container(pluto, "API gateway", "Java, Spring Boot", "Proxies API requests and keeps authenticated session")
+    Container(portal, "Portal", "Java, Jetty, Apache Spark", "Provides APIs for managing workspaces and apps")
+    Container(rabbitmq, "Message Bus", "RabbitMQ", "Transport for business events")
+    Container(auditlog, "Log aggregator", "Java", "Stores relevant business events in a separate audit log")
+}
+
+System_Ext(k8s, "Kubernetes", "Platform for managing containerized workloads and services")
+System_Ext(tiller, "Tiller", "Server side component managing helm releases")
+
+Rel(tiller, k8s, "Manages resources and stores releases in")
+
+Rel(admin, frontend, "Manages workspaces and apps")
+Rel(admin, keycloak, "Logs in at ")
+
+Rel(frontend, pluto, "Updates workspace, app and auth information via")
+Rel_R(pluto, keycloak, "Proxies admin API on")
+Rel(pluto, portal, "Proxies workspace, app and search API on")
+Rel_L(pluto, rabbitmq, "Sends authentication events to", "AMQP")
+Rel(portal, tiller, "Manages releases with")
+Rel(portal, elasticsearch, "Queries appropriate indices")
+Rel(portal, rabbitmq, "Sends workspace and app events to", "AMQP")
+Rel_R(auditlog, rabbitmq, "Listens to events from", "AMQP")
+@enduml

--- a/docs/context-diagram.puml
+++ b/docs/context-diagram.puml
@@ -1,0 +1,29 @@
+@startuml Fairspace
+!includeurl https://raw.githubusercontent.com/RicardoNiepel/C4-PlantUML/release/1-0/C4_Context.puml
+
+title Context diagram for Fairspace
+
+LAYOUT_WITH_LEGEND()
+
+Person(admin, "Administrator", "An organisation wide administrator for fairspace")
+Person(user, "Regular user", "A user without any additional privileges")
+Person(datasteward, "Datasteward", "A user appointed to manage the data model")
+
+System_Boundary(fairspace, "Fairspace installation") {
+    System(hyperspace, "Hyperspace", "Allows admins to manage workspaces, apps and users")
+    System(workspace, "Workspace", "Stores files and associated metadatadata with a configurable model")
+    System(jupyterhub, "JupyterHub", "Provides environment for running scripts on the data and metadata in a workspace")
+}
+
+System_Ext(irods, "iRODS", "Handles storage of files")
+
+Rel(admin, hyperspace, "Manages workspaces, apps and roles")
+Rel(hyperspace, workspace, "Instantiates one or more")
+Rel(hyperspace, jupyterhub, "Adds to a workspace")
+Rel(jupyterhub, workspace, "Reads files from")
+Rel(workspace, irods, "(Optionally) stores files in ")
+
+Rel(user, workspace, "Manages files and metadata")
+Rel(datasteward, workspace, "Manages metadata model")
+
+@enduml


### PR DESCRIPTION
These diagrams describe the context and setup of a fairspace hyperspace
using the C4 terminology (www.c4model.com) in plantuml syntax. (www.plantuml.com)
The files can be viewed using an IDE plugin, a standalone application or
online at https://plantuml-editor.kkeisuke.com