### PR TITLE
Upgrade keycloak to version 7.0.0

### DIFF
--- a/.travis/ci-values.yaml
+++ b/.travis/ci-values.yaml
@@ -15,8 +15,8 @@ hyperspace:
 keycloak:
   keycloak:
     password: keycloak-ci-123
-  postgresql:
-    postgresPassword: "9FGwLKpEu$4w/knG"
+    persistence:
+      postgresqlPassword: "9FGwLKpEu$4w/knG"
 
 rabbitmq:
   rabbitmq:

--- a/.travis/demo-values.yaml
+++ b/.travis/demo-values.yaml
@@ -13,8 +13,8 @@ hyperspace:
 keycloak:
   keycloak:
     password: keycloak-demo-123
-  postgresql:
-    postgresPassword: "mf5-Y5Q5E5_P33eB"
+    persistence:
+      postgresqlPassword: "mf5-Y5Q5E5_P33eB"
 
 rabbitmq:
   rabbitmq:

--- a/charts/hyperspace/requirements.lock
+++ b/charts/hyperspace/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: keycloak
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 2.0.0
+  repository: https://codecentric.github.io/helm-charts
+  version: 6.0.0
 - name: elasticsearch
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.31.0
 - name: rabbitmq
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 6.5.0
-digest: sha256:bf0a944a425c4f1f71f19b1409f3364365f92ee315bcfc6e76ac766e82cf4676
-generated: "2019-09-25T12:22:38.713133271+02:00"
+digest: sha256:afb5490ae1d3e39f1068d3f25cb0cb9a1482e389445b45453cfaa5b76dcaa6c4
+generated: "2019-10-23T15:18:58.701224146+02:00"

--- a/charts/hyperspace/requirements.yaml
+++ b/charts/hyperspace/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: keycloak
-  version: "2.0.0"
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: "6.0.0"
+  repository: https://codecentric.github.io/helm-charts
   condition: keycloak.enabled
 - name: elasticsearch
   version: "1.31.0"

--- a/charts/hyperspace/values.yaml
+++ b/charts/hyperspace/values.yaml
@@ -70,6 +70,7 @@ keycloak:
             port: 80
         ingress:
             enabled: false
+        extraArgs: "-Dkeycloak.profile.feature.admin_fine_grained_authz=enabled"
         resources:
             requests:
                 cpu: "10m"
@@ -77,9 +78,11 @@ keycloak:
             limits:
                 cpu: "500m"
                 memory: "2048Mi"
-    postgresql:
         persistence:
-            enabled: true
+            deployPostgres: true
+            dbVendor: postgres
+            postgresqlPassword:
+    postgresql:
         resources:
             # Request values are set by default in postgresql chart
             limits:


### PR DESCRIPTION
This upgrade brings the version of keycloak up to date. This helps
in keeping regular (security) updates and using the latest features.

Please note that due to the changes in the way postgresql is being
deployed, it may be needed to redeploy the hyperspace

Fixes VRE-696